### PR TITLE
Add /assistant-retrieve retrieval endpoint

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,17 +1,17 @@
 name: Deploy Cloudflare Worker
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "cloudflare-worker/**"
-      - "content/**"
-      - "public/api/resume.json"
-      - "scripts/generate-resume-json.mjs"
-      - "package.json"
-      - "yarn.lock"
-      - ".github/workflows/deploy-worker.yml"
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - "cloudflare-worker/**"
+  #     - "content/**"
+  #     - "public/api/resume.json"
+  #     - "scripts/generate-resume-json.mjs"
+  #     - "package.json"
+  #     - "yarn.lock"
+  #     - ".github/workflows/deploy-worker.yml"
   workflow_dispatch:
 
 permissions:

--- a/cloudflare-worker/src/__tests__/rag.test.ts
+++ b/cloudflare-worker/src/__tests__/rag.test.ts
@@ -77,7 +77,9 @@ describe("/ask", () => {
 		);
 
 		expect(response.status).toBe(400);
-		expect((await response.json()).error).toBe("Validation failed");
+		expect(((await response.json()) as { error: string }).error).toBe(
+			"Validation failed",
+		);
 	});
 
 	it("returns no_match without calling the generation model", async () => {
@@ -108,7 +110,7 @@ describe("/ask", () => {
 			env as never,
 		);
 
-		const payload = await response.json();
+		const payload = (await response.json()) as { status: string };
 		expect(response.status).toBe(200);
 		expect(payload.status).toBe("no_match");
 		expect(env.AI.run).toHaveBeenCalledTimes(1);
@@ -147,7 +149,9 @@ describe("/ask", () => {
 		expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
 			"https://worker.test",
 		);
-		expect((await response.json()).status).toBe("no_match");
+		expect(((await response.json()) as { status: string }).status).toBe(
+			"no_match",
+		);
 	});
 
 	it("returns an answered payload with citations when retrieval succeeds", async () => {
@@ -204,7 +208,11 @@ describe("/ask", () => {
 			env as never,
 		);
 
-		const payload = await response.json();
+		const payload = (await response.json()) as {
+			status: string;
+			citations: unknown[];
+			answer: string;
+		};
 		expect(response.status).toBe(200);
 		expect(payload.status).toBe("answered");
 		expect(payload.citations).toHaveLength(1);

--- a/cloudflare-worker/src/__tests__/worker.test.js
+++ b/cloudflare-worker/src/__tests__/worker.test.js
@@ -287,14 +287,9 @@ describe("/assistant", () => {
 	});
 
 	it("proxies embeddings requests for an allowed origin", async () => {
-		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(
-				JSON.stringify({
-					data: [{ embedding: [0.1, 0.2, 0.3] }],
-				}),
-				{ status: 200, headers: { "Content-Type": "application/json" } },
-			),
-		);
+		const aiRun = vi.fn().mockResolvedValue({
+			data: [[0.1, 0.2, 0.3]],
+		});
 
 		const response = await worker.fetch(
 			buildPathRequest("/assistant", "POST", ALLOWED_ORIGIN, {
@@ -304,7 +299,9 @@ describe("/assistant", () => {
 			}),
 			{
 				...env,
-				GITHUB_MODELS_TOKEN: "ghm_test",
+				AI: {
+					run: aiRun,
+				},
 			},
 		);
 
@@ -313,17 +310,16 @@ describe("/assistant", () => {
 			ALLOWED_ORIGIN,
 		);
 		expect((await response.json()).data[0].embedding).toEqual([0.1, 0.2, 0.3]);
+		expect(aiRun).toHaveBeenCalledWith("openai/text-embedding-3-small", {
+			text: ["test snippet"],
+			pooling: "cls",
+		});
 	});
 
 	it("allows localhost origins for local development", async () => {
-		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(
-				JSON.stringify({
-					data: [{ embedding: [0.1, 0.2, 0.3] }],
-				}),
-				{ status: 200, headers: { "Content-Type": "application/json" } },
-			),
-		);
+		const aiRun = vi.fn().mockResolvedValue({
+			data: [[0.1, 0.2, 0.3]],
+		});
 
 		const response = await worker.fetch(
 			new Request("http://127.0.0.1:8787/assistant", {
@@ -340,7 +336,9 @@ describe("/assistant", () => {
 			}),
 			{
 				...env,
-				GITHUB_MODELS_TOKEN: "ghm_test",
+				AI: {
+					run: aiRun,
+				},
 			},
 		);
 
@@ -351,14 +349,9 @@ describe("/assistant", () => {
 	});
 
 	it("allows 0.0.0.0 local origins for local development", async () => {
-		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(
-				JSON.stringify({
-					data: [{ embedding: [0.1, 0.2, 0.3] }],
-				}),
-				{ status: 200, headers: { "Content-Type": "application/json" } },
-			),
-		);
+		const aiRun = vi.fn().mockResolvedValue({
+			data: [[0.1, 0.2, 0.3]],
+		});
 
 		const response = await worker.fetch(
 			new Request("http://127.0.0.1:8787/assistant", {
@@ -375,7 +368,9 @@ describe("/assistant", () => {
 			}),
 			{
 				...env,
-				GITHUB_MODELS_TOKEN: "ghm_test",
+				AI: {
+					run: aiRun,
+				},
 			},
 		);
 

--- a/cloudflare-worker/src/index.ts
+++ b/cloudflare-worker/src/index.ts
@@ -2,7 +2,11 @@ import { Hono } from "hono";
 import { createMiddleware } from "hono/factory";
 import { z } from "zod";
 import type { RagEnv } from "./rag/types";
-import { handleAskRequest, handleRagHomeRequest } from "./rag-app";
+import {
+	handleAskRequest,
+	handleRagHomeRequest,
+	handleRetrieveRequest,
+} from "./rag-app";
 import {
 	corsHeaders,
 	createRedirectResponse,
@@ -41,6 +45,7 @@ type WorkerEnv = Record<string, unknown> & {
 	FROM_EMAIL?: string;
 	TURNSTILE_SECRET_KEY?: string;
 	GITHUB_MODELS_CHAT_MODEL?: string;
+	RAG_EMBED_MODEL?: string;
 	ASSISTANT_PROVIDER_PRIORITY?: string;
 };
 
@@ -353,25 +358,81 @@ async function handleAssistantRequest(
 		);
 	}
 
-	const proxyResponse =
-		data.action === "embeddings"
-			? await callGitHubModels("/inference/embeddings", env, {
-					model: data.model,
-					input: data.input,
-					encoding_format: "float",
+	const proxyResponse = await (data.action === "embeddings"
+		? (() => {
+				const embeddingModel =
+					data.model || env.RAG_EMBED_MODEL || "@cf/baai/bge-small-en-v1.5";
+
+				if (!env.AI) {
+					return Promise.resolve(
+						jsonResponse(
+							{ error: "Workers AI is not configured for embeddings." },
+							503,
+							corsHeaders(origin),
+						),
+					);
+				}
+
+				const inputTexts = Array.isArray(data.input)
+					? data.input
+					: [data.input];
+
+				return env.AI.run(embeddingModel, {
+					text: inputTexts,
+					pooling: "cls",
 				})
-			: routeChatWithFallbacks
-				? await callAssistantChatWithRouting(env, {
-						...data,
-						model: data.model || defaultChatModel,
+					.then((result) => {
+						const vectors = (result as { data?: number[][] })?.data;
+
+						if (
+							!Array.isArray(vectors) ||
+							!vectors.length ||
+							!Array.isArray(vectors[0])
+						) {
+							return jsonResponse(
+								{ error: "Embedding model did not return vectors." },
+								502,
+								corsHeaders(origin),
+							);
+						}
+
+						return jsonResponse(
+							{
+								data: vectors.map((embedding, index) => ({
+									object: "embedding",
+									index,
+									embedding,
+								})),
+							},
+							200,
+							corsHeaders(origin),
+						);
 					})
-				: await callGitHubModels("/inference/chat/completions", env, {
-						model: data.model || defaultChatModel,
-						temperature: data.temperature ?? 0,
-						max_tokens: data.max_tokens ?? 220,
-						response_format: data.response_format,
-						messages: data.messages,
-					});
+					.catch((error) =>
+						jsonResponse(
+							{
+								error:
+									error instanceof Error
+										? error.message
+										: "Embedding request failed.",
+							},
+							502,
+							corsHeaders(origin),
+						),
+					);
+			})()
+		: routeChatWithFallbacks
+			? await callAssistantChatWithRouting(env, {
+					...data,
+					model: data.model || defaultChatModel,
+				})
+			: await callGitHubModels("/inference/chat/completions", env, {
+					model: data.model || defaultChatModel,
+					temperature: data.temperature ?? 0,
+					max_tokens: data.max_tokens ?? 220,
+					response_format: data.response_format,
+					messages: data.messages,
+				}));
 
 	const headers = new Headers(proxyResponse.headers);
 
@@ -590,11 +651,16 @@ app.use("/contact", requireAllowedOrigin);
 app.use("/assistant", requireAllowedOrigin);
 app.use("/assistant-routed", requireAllowedOrigin);
 app.use("/assistant-provider-raw", requireAllowedOrigin);
+app.use("/assistant-retrieve", requireAllowedOrigin);
 
 app.get("/", () => handleRagHomeRequest());
 
 app.all("/ask", async (c) =>
 	handleAskRequest(c.req.raw, c.env as unknown as RagEnv),
+);
+
+app.all("/assistant-retrieve", async (c) =>
+	handleRetrieveRequest(c.req.raw, c.env as unknown as RagEnv),
 );
 
 app.all("/auth", async (c) => {

--- a/cloudflare-worker/src/rag-app.ts
+++ b/cloudflare-worker/src/rag-app.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { getRagConfig } from "./rag/config";
 import { createAskResponse, jsonResponse } from "./rag/response";
 import { generateAnswer, retrieveChunks } from "./rag/retrieve";
-import type { RagEnv } from "./rag/types";
+import type { RagEnv, RagRetrieveResponse } from "./rag/types";
 import { corsHeaders } from "./utils/http";
 import { getRequestOrigin, isAllowedOrigin } from "./utils/origin";
 
@@ -13,6 +13,20 @@ const askRequestSchema = z.object({
 		.trim()
 		.min(1, "question is required")
 		.max(500, "question is too long"),
+});
+
+const retrieveRequestSchema = z.object({
+	question: z
+		.string()
+		.trim()
+		.min(1, "question is required")
+		.max(500, "question is too long"),
+	query: z
+		.string()
+		.trim()
+		.min(1, "query is required")
+		.max(2000, "query is too long")
+		.optional(),
 });
 
 const app = new Hono<{ Bindings: RagEnv }>();
@@ -339,7 +353,7 @@ export function renderRagHomePage() {
         <div class="panel">
           <div class="eyebrow">Assistant Worker Debug</div>
           <h1>Portfolio assistant provider console.</h1>
-          <p class="lede">Use the same worker routes that power the portfolio assistant. This page now defaults to raw provider calls through <code>/assistant-provider-raw</code>, while keeping grounded <code>/ask</code> available as a second path for RAG verification.</p>
+          <p class="lede">Use the same worker routes that power the portfolio assistant. This page now defaults to raw provider calls through <code>/assistant-provider-raw</code>, while keeping semantic chunk inspection and frontend-style routed calls available for retrieval debugging.</p>
           <div class="chips">
             <div class="chip">GitHub Models</div>
             <div class="chip">Groq</div>
@@ -350,7 +364,8 @@ export function renderRagHomePage() {
         </div>
         <div class="panel meta">
           <div class="meta-row"><strong>Primary action</strong><span>Raw provider debug</span></div>
-          <div class="meta-row"><strong>Secondary action</strong><span>Grounded <code>/ask</code> check</span></div>
+          <div class="meta-row"><strong>Secondary action</strong><span>Cloudflare semantic retrieval</span></div>
+          <div class="meta-row"><strong>Routed simulation</strong><span>Frontend-style <code>/assistant-routed</code> payload</span></div>
           <div class="meta-row"><strong>Same worker origin</strong><span>Calls stay on this deployment</span></div>
           <div class="meta-row"><strong>Best use</strong><span>Compare provider behavior quickly</span></div>
         </div>
@@ -370,7 +385,7 @@ export function renderRagHomePage() {
           <div class="panel controls">
             <div>
               <h2 class="section-title">Raw Provider Debug</h2>
-              <p class="section-copy">This mirrors the portfolio assistant debug mode and posts to <code>/assistant-provider-raw</code>. Keep structured output on if you want the same JSON-shaped assistant contract.</p>
+              <p class="section-copy">This mirrors the portfolio assistant debug mode and posts to <code>/assistant-provider-raw</code>. You can also inspect Vectorize-backed snippets through <code>/assistant-retrieve</code> and send those snippets through a frontend-style <code>/assistant-routed</code> request.</p>
             </div>
             <div class="control-grid">
               <label>
@@ -396,20 +411,26 @@ export function renderRagHomePage() {
                 <input id="maxTokens" inputmode="numeric" value="500" />
               </label>
             </div>
-            <label>
-              <span>Question</span>
-              <textarea id="question" placeholder="Ask about experience, systems work, projects, education, recommendations, or technical strengths..."></textarea>
-            </label>
+              <label>
+                <span>Question</span>
+                <textarea id="question" placeholder="Ask about experience, systems work, projects, education, recommendations, or technical strengths..."></textarea>
+              </label>
+              <label>
+                <span>Retrieval query override</span>
+                <textarea id="retrievalQuery" placeholder="Optional. Leave empty to use the same question for semantic retrieval."></textarea>
+              </label>
             <label class="checkbox">
               <input checked id="structuredOutput" type="checkbox" />
               <span>Request structured JSON output like the portfolio assistant debug UI</span>
             </label>
             <div class="actions">
               <button id="askRaw" type="button">Call /assistant-provider-raw</button>
+              <button class="secondary" id="askRetrieve" type="button">Call /assistant-retrieve</button>
+              <button class="secondary" id="askRouted" type="button">Call frontend-style /assistant-routed</button>
               <button class="secondary" id="askRag" type="button">Call grounded /ask</button>
               <span class="status" id="status">Idle</span>
             </div>
-            <p class="footnote">Provider raw calls are useful for direct model behavior. The grounded <code>/ask</code> route is useful when you want to inspect retrieval-first RAG behavior specifically.</p>
+            <p class="footnote">Provider raw calls are useful for direct model behavior. <code>/assistant-retrieve</code> shows Cloudflare semantic chunk matches, and the frontend-style routed action forwards those snippets to <code>/assistant-routed</code> in the same shape the site uses.</p>
           </div>
         </div>
         <div class="panel stack">
@@ -464,6 +485,7 @@ export function renderRagHomePage() {
       const maxTokensEl = document.getElementById("maxTokens");
       const structuredOutputEl = document.getElementById("structuredOutput");
       const questionEl = document.getElementById("question");
+      const retrievalQueryEl = document.getElementById("retrievalQuery");
       const outputEl = document.getElementById("output");
       const statusEl = document.getElementById("status");
       const endpointLabelEl = document.getElementById("endpointLabel");
@@ -508,6 +530,79 @@ export function renderRagHomePage() {
         return {
           provider,
           request
+        };
+      }
+
+      async function fetchSemanticRetrieval(question) {
+        const query = retrievalQueryEl.value.trim();
+        const response = await fetch("/assistant-retrieve", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            question,
+            ...(query ? { query } : {})
+          }),
+        });
+
+        const payload = await response.json().catch(() => null);
+
+        if (!response.ok) {
+          throw new Error(
+            payload && typeof payload.error === "string"
+              ? payload.error
+              : "Semantic retrieval request failed."
+          );
+        }
+
+        return payload;
+      }
+
+      function createFrontendStyleRoutedRequest(question, retrievalPayload) {
+        const snippets = Array.isArray(retrievalPayload?.chunks)
+          ? retrievalPayload.chunks.map((chunk) => ({
+              id: chunk.id,
+              title: chunk.title,
+              text: chunk.text,
+            }))
+          : [];
+        const snippetList = snippets.length
+          ? snippets
+              .map((snippet) => "[" + snippet.id + "] " + snippet.title + "\n" + snippet.text)
+              .join("\n\n")
+          : "None";
+        const temperatureValue = Number.parseFloat(temperatureEl.value);
+        const maxTokensValue = Number.parseInt(maxTokensEl.value, 10);
+
+        return {
+          action: "chat",
+          ...(modelEl.value.trim() ? { model: modelEl.value.trim() } : {}),
+          temperature: Number.isFinite(temperatureValue) ? temperatureValue : 0,
+          max_tokens: Number.isFinite(maxTokensValue) && maxTokensValue > 0 ? maxTokensValue : 500,
+          response_format: structuredOutputEl.checked ? STRUCTURED_RESPONSE_FORMAT : undefined,
+          messages: [
+            {
+              role: "system",
+              content: 'You are an AI assistant embedded on this portfolio website.\n\nRules:\n\n* ONLY answer using provided resume data\n* If info is missing: "I don\\'t have that information available."\n* Do NOT hallucinate or guess\n* ONLY answer about the person described in the provided resume data\n* Reject unrelated questions\n\nTone:\n\n* Professional\n* Concise\n* Friendly'
+            },
+            {
+              role: "developer",
+              content: [
+                "Use only the SUPPORTING_RESUME_SNIPPETS below.",
+                'If the snippets do not contain the answer, respond with status "missing" and answer exactly: I don't have that information available.',
+                'If the question is unrelated to the person described in the resume or recommendations, respond with status "rejected" and answer exactly: I can only answer questions based on the information available on this site.',
+                "Do not infer, invent, generalize, or use outside knowledge.",
+                "Every factual answer must be grounded in the snippet IDs you cite.",
+                "",
+                "RECENT_CHAT_CONTEXT:\nNone",
+                "",
+                "SUPPORTING_RESUME_SNIPPETS:\n" + snippetList
+              ].join("\n")
+            },
+            {
+              role: "user",
+              content: question
+            }
+          ]
         };
       }
 
@@ -569,6 +664,59 @@ export function renderRagHomePage() {
           return;
         }
         callEndpoint("/ask", { question }, "portfolio-rag");
+      });
+
+      document.getElementById("askRetrieve").addEventListener("click", async () => {
+        const question = questionEl.value.trim();
+        if (!question) {
+          statusEl.textContent = "Enter a question first";
+          return;
+        }
+
+        statusEl.textContent = "Calling /assistant-retrieve...";
+        endpointLabelEl.textContent = "/assistant-retrieve";
+        providerLabelEl.textContent = "cloudflare-vectorize";
+        statusCodeEl.textContent = "pending";
+        outputEl.textContent = "Loading...";
+
+        try {
+          const payload = await fetchSemanticRetrieval(question);
+          outputEl.textContent = JSON.stringify({
+            endpoint: "/assistant-retrieve",
+            query: retrievalQueryEl.value.trim() || question,
+            payload
+          }, null, 2);
+          statusCodeEl.textContent = "200";
+          statusEl.textContent = "Done";
+        } catch (error) {
+          outputEl.textContent = JSON.stringify({ error: String(error) }, null, 2);
+          statusCodeEl.textContent = "failed";
+          statusEl.textContent = "Request failed";
+        }
+      });
+
+      document.getElementById("askRouted").addEventListener("click", async () => {
+        const question = questionEl.value.trim();
+        if (!question) {
+          statusEl.textContent = "Enter a question first";
+          return;
+        }
+
+        statusEl.textContent = "Building frontend-style routed request...";
+        endpointLabelEl.textContent = "/assistant-routed";
+        providerLabelEl.textContent = "routed";
+        statusCodeEl.textContent = "pending";
+        outputEl.textContent = "Loading...";
+
+        try {
+          const retrievalPayload = await fetchSemanticRetrieval(question);
+          const body = createFrontendStyleRoutedRequest(question, retrievalPayload);
+          await callEndpoint("/assistant-routed", body, "routed");
+        } catch (error) {
+          outputEl.textContent = JSON.stringify({ error: String(error) }, null, 2);
+          statusCodeEl.textContent = "failed";
+          statusEl.textContent = "Request failed";
+        }
       });
 
       for (const button of document.querySelectorAll(".example")) {
@@ -707,9 +855,125 @@ export async function handleAskRequest(request: Request, env: RagEnv) {
 	}
 }
 
+export async function handleRetrieveRequest(request: Request, env: RagEnv) {
+	const config = getRagConfig(env);
+	const url = new URL(request.url);
+	const origin = getRequestOrigin(request, url);
+
+	if (!origin || !isAllowedOrigin(origin, env, url.origin)) {
+		return jsonResponse({ error: "Invalid origin" }, 403, origin);
+	}
+
+	if (request.method === "OPTIONS") {
+		return new Response(null, {
+			status: 204,
+			headers: corsHeaders(origin),
+		});
+	}
+
+	if (request.method !== "POST") {
+		return jsonResponse({ error: "Method not allowed" }, 405, origin);
+	}
+
+	if (
+		!request.headers
+			.get("content-type")
+			?.toLowerCase()
+			.includes("application/json")
+	) {
+		return jsonResponse({ error: "Expected application/json" }, 415, origin);
+	}
+
+	let body: unknown;
+
+	try {
+		body = await request.json();
+	} catch {
+		return jsonResponse({ error: "Invalid JSON body" }, 400, origin);
+	}
+
+	const parsed = retrieveRequestSchema.safeParse(body);
+	if (!parsed.success) {
+		return jsonResponse(
+			{
+				error: "Validation failed",
+				fields: parsed.error.issues.map((issue) => issue.message),
+			},
+			400,
+			origin,
+		);
+	}
+
+	try {
+		const retrievalQuery = parsed.data.query || parsed.data.question;
+		const retrieval = await retrieveChunks(retrievalQuery, env, config);
+
+		if (retrieval.status === "no_match") {
+			return jsonResponse(
+				{
+					ok: true,
+					status: "no_match",
+					matched: 0,
+					chunks: [],
+				} satisfies RagRetrieveResponse,
+				200,
+				origin,
+			);
+		}
+
+		if (retrieval.status === "insufficient_context") {
+			return jsonResponse(
+				{
+					ok: true,
+					status: "insufficient_context",
+					matched: retrieval.matched,
+					chunks: [],
+				} satisfies RagRetrieveResponse,
+				200,
+				origin,
+			);
+		}
+
+		return jsonResponse(
+			{
+				ok: true,
+				status: "ready",
+				matched: retrieval.matched,
+				chunks: retrieval.citations.map((citation, index) => ({
+					id: citation.id,
+					sourceType: citation.sourceType,
+					title: citation.title,
+					text: retrieval.chunks[index]?.text || "",
+					url: citation.url,
+					slug: citation.slug,
+					section: citation.section,
+					score: citation.score,
+				})),
+			} satisfies RagRetrieveResponse,
+			200,
+			origin,
+		);
+	} catch (error) {
+		return jsonResponse(
+			{
+				ok: false,
+				status: "error",
+				matched: 0,
+				chunks: [],
+				error: error instanceof Error ? error.message : "Unknown error",
+			} satisfies RagRetrieveResponse,
+			502,
+			origin,
+		);
+	}
+}
+
 app.get("/", () => handleRagHomeRequest());
 
 app.all("/ask", async (c) => handleAskRequest(c.req.raw, c.env));
+app.all("/assistant-retrieve", async (c) =>
+	handleRetrieveRequest(c.req.raw, c.env),
+);
 
 app.notFound((c) => {
 	const origin = getRequestOrigin(c.req.raw, new URL(c.req.raw.url));

--- a/cloudflare-worker/src/rag-app.ts
+++ b/cloudflare-worker/src/rag-app.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { getRagConfig } from "./rag/config";
 import { createAskResponse, jsonResponse } from "./rag/response";
 import { generateAnswer, retrieveChunks } from "./rag/retrieve";
-import type { RagEnv, RagRetrieveResponse, RagRetrieveResponse } from "./rag/types";
+import type { RagEnv, RagRetrieveResponse } from "./rag/types";
 import { corsHeaders } from "./utils/http";
 import { getRequestOrigin, isAllowedOrigin } from "./utils/origin";
 
@@ -26,20 +26,6 @@ const retrieveRequestSchema = z.object({
 		.trim()
 		.min(1, "query is required")
 		.max(5000, "query is too long")
-		.optional(),
-});
-
-const retrieveRequestSchema = z.object({
-	question: z
-		.string()
-		.trim()
-		.min(1, "question is required")
-		.max(500, "question is too long"),
-	query: z
-		.string()
-		.trim()
-		.min(1, "query is required")
-		.max(2000, "query is too long")
 		.optional(),
 });
 

--- a/cloudflare-worker/src/rag-app.ts
+++ b/cloudflare-worker/src/rag-app.ts
@@ -25,7 +25,7 @@ const retrieveRequestSchema = z.object({
 		.string()
 		.trim()
 		.min(1, "query is required")
-		.max(2000, "query is too long")
+		.max(5000, "query is too long")
 		.optional(),
 });
 

--- a/cloudflare-worker/src/rag/response.ts
+++ b/cloudflare-worker/src/rag/response.ts
@@ -1,4 +1,9 @@
-import type { RagAskResponse, RagCitation, RagConfig } from "./types";
+import type {
+	RagAskResponse,
+	RagCitation,
+	RagConfig,
+	RagRetrieveResponse,
+} from "./types";
 
 function buildCorsHeaders(origin: string | null) {
 	return {
@@ -10,7 +15,10 @@ function buildCorsHeaders(origin: string | null) {
 }
 
 export function jsonResponse(
-	body: RagAskResponse | { error: string; fields?: string[] },
+	body:
+		| RagAskResponse
+		| RagRetrieveResponse
+		| { error: string; fields?: string[] },
 	status: number,
 	origin: string | null,
 ) {

--- a/cloudflare-worker/src/rag/types.ts
+++ b/cloudflare-worker/src/rag/types.ts
@@ -38,6 +38,25 @@ export type RagAskResponse = {
 	error?: string;
 };
 
+export type RagRetrieveChunk = {
+	id: string;
+	sourceType: string;
+	title: string;
+	text: string;
+	url?: string;
+	slug?: string;
+	section: string;
+	score: number;
+};
+
+export type RagRetrieveResponse = {
+	ok: boolean;
+	status: "ready" | "no_match" | "insufficient_context" | "error";
+	matched: number;
+	chunks: RagRetrieveChunk[];
+	error?: string;
+};
+
 export type RagEnv = {
 	AI: {
 		run(model: string, input: Record<string, unknown>): Promise<unknown>;

--- a/cloudflare-worker/wrangler.jsonc
+++ b/cloudflare-worker/wrangler.jsonc
@@ -26,7 +26,7 @@
   "vars": {
     "GITHUB_OAUTH_SCOPE": "public_repo",
     "ALLOWED_GITHUB_USERS": "autodidactGuy",
-    "ALLOWED_ORIGINS": "https://hassanraza.us",
+    "ALLOWED_ORIGINS": "https://hassanraza.us,https://stage.hassanraza.us,https://preview.hassanraza.us",
     "ORIGIN": "https://hassanraza.us",
     "REPO_BASE_PATH": "",
     "CONTACT_EMAIL": "hassanraza632@gmail.com",

--- a/src/components/resume-assistant.tsx
+++ b/src/components/resume-assistant.tsx
@@ -19,21 +19,18 @@ import {
 	buildResumeSnippets,
 	buildRetrievalQuery,
 	checkQuestionGuardrails,
-	DEFAULT_EMBEDDING_MODEL,
-	EMBEDDINGS_CACHE_TTL_MS,
 	fetchAssistantRawProviderResponse,
 	fetchAssistantResponse,
-	fetchEmbeddings,
+	fetchSemanticRelevantSnippets,
 	findAssistantInlineLinkMatches,
 	type GuardrailResult,
 	generateLocalResumeAnswer,
 	generateLocalSmallTalkAnswer,
 	getAssistantWorkerUrl,
-	getEmbeddingsCacheKey,
 	getSnippetHref,
-	hashResumePayload,
 	MISSING_INFORMATION_MESSAGE,
-	RESPONSE_CACHE_PREFIX,
+	mergeRetrievalResults,
+	mergeUniqueSnippets,
 	type ResumePayload,
 	type ResumeSnippet,
 	type RetrievalResult,
@@ -52,18 +49,17 @@ type ChatMessage = {
 	citations?: ResumeSnippet[];
 };
 
-type EmbeddingStatus = "idle" | "loading" | "ready" | "fallback";
-
-type EmbeddingsCachePayload = {
-	createdAt: number;
-	embeddings: number[][];
-};
-
 const CONVERSATION_STORAGE_KEY = "portfolio-assistant-conversation";
 const IS_LOCAL_DEVELOPMENT = process.env.NODE_ENV === "development";
 
 type AssistantDebugState = {
 	retrievalResult: RetrievalResult | null;
+	keywordEntries: RetrievalResult["entries"] | null;
+	semanticEntries: RetrievalResult["entries"] | null;
+	semanticMatched: number | null;
+	initialSnippetIds: string[] | null;
+	finalSnippetIds: string[] | null;
+	recentContextIncluded: boolean | null;
 	usedClosestMatchFallback: boolean;
 	fallbackReason: string | null;
 	lastProvider: string | null;
@@ -79,76 +75,6 @@ type AssistantRawDebugResult = {
 	provider: string | null;
 	content: string;
 };
-
-function isEmbeddingsRateLimitError(error: unknown) {
-	return (
-		error instanceof Error &&
-		(/status 429/i.test(error.message) ||
-			/too many requests/i.test(error.message) ||
-			/rate limit/i.test(error.message))
-	);
-}
-
-function readLegacyEmbeddingsCache(args: {
-	hash: string;
-	model: string;
-	snippetCount: number;
-}) {
-	if (typeof window === "undefined") {
-		return null;
-	}
-
-	const { hash, model, snippetCount } = args;
-	const currentKey = getEmbeddingsCacheKey(hash, model);
-	const suffix = `:${model}:${hash}`;
-	const matchingKeys: string[] = [];
-
-	for (let index = 0; index < window.localStorage.length; index += 1) {
-		const key = window.localStorage.key(index);
-
-		if (
-			key &&
-			key !== currentKey &&
-			key.startsWith(`${RESPONSE_CACHE_PREFIX}:`) &&
-			key.endsWith(suffix)
-		) {
-			matchingKeys.push(key);
-		}
-	}
-
-	for (const key of matchingKeys.sort().reverse()) {
-		try {
-			const cachedValue = window.localStorage.getItem(key);
-
-			if (!cachedValue) {
-				continue;
-			}
-
-			const parsed = JSON.parse(cachedValue) as
-				| number[][]
-				| EmbeddingsCachePayload;
-			const parsedEmbeddings = Array.isArray(parsed)
-				? parsed
-				: parsed.embeddings;
-			const cacheAge = Array.isArray(parsed)
-				? Number.POSITIVE_INFINITY
-				: Date.now() - parsed.createdAt;
-			const cacheIsFresh = cacheAge <= EMBEDDINGS_CACHE_TTL_MS;
-
-			if (
-				cacheIsFresh &&
-				Array.isArray(parsedEmbeddings) &&
-				parsedEmbeddings.length === snippetCount
-			) {
-				return parsedEmbeddings;
-			}
-		} catch {
-			// Ignore malformed legacy cache entries.
-		}
-	}
-
-	return null;
-}
 
 function renderMessageContent(
 	content: string,
@@ -310,6 +236,12 @@ function normalizeAssistantDisplayContent(content: string) {
 		.replace(/\r\n/g, "\n")
 		.replace(/\\n/g, "\n")
 		.replace(/\/n/g, "\n")
+		.replace(/:\s*(\d+\.\s*)/g, ":\n$1")
+		.replace(/([A-Za-z),])(\d+\.\s*)/g, "$1\n$2")
+		.replace(
+			/([A-Za-z.)])(?=(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b)/g,
+			"$1\n",
+		)
 		.replace(/【[^】]+】/g, "")
 		.replace(
 			/\[(summary|about|skills|links|contact|hero|focus|stats|experience:[^\]]+|education:[^\]]+|project:[^\]]+|article:[^\]]+|case-study:[^\]]+|recommendation:[^\]]+)\]/gi,
@@ -480,7 +412,6 @@ export function ResumeAssistant() {
 
 	const [resume, setResume] = useState<ResumePayload | null>(null);
 	const [snippets, setSnippets] = useState<ResumeSnippet[]>([]);
-	const [resumeHash, setResumeHash] = useState("");
 	const [resumeError, setResumeError] = useState("");
 	const [messages, setMessages] = useState<ChatMessage[]>(() => {
 		if (typeof window === "undefined") {
@@ -505,12 +436,15 @@ export function ResumeAssistant() {
 	});
 	const [draft, setDraft] = useState("");
 	const [isSending, setIsSending] = useState(false);
-	const [_embeddingStatus, setEmbeddingStatus] =
-		useState<EmbeddingStatus>("idle");
-	const [_snippetEmbeddings, setSnippetEmbeddings] = useState<number[][]>([]);
 	const [statusMessage, setStatusMessage] = useState("");
 	const [debugState, setDebugState] = useState<AssistantDebugState>({
 		retrievalResult: null,
+		keywordEntries: null,
+		semanticEntries: null,
+		semanticMatched: null,
+		initialSnippetIds: null,
+		finalSnippetIds: null,
+		recentContextIncluded: null,
 		usedClosestMatchFallback: false,
 		fallbackReason: null,
 		lastProvider: null,
@@ -566,11 +500,9 @@ export function ResumeAssistant() {
 
 				const payload = (await response.json()) as ResumePayload;
 				const nextSnippets = buildResumeSnippets(payload);
-				const nextHash = await hashResumePayload(payload);
 
 				setResume(payload);
 				setSnippets(nextSnippets);
-				setResumeHash(nextHash);
 				setMessages((currentMessages) => {
 					const welcomeName = payload.name || "the person in this resume";
 
@@ -639,109 +571,6 @@ export function ResumeAssistant() {
 		}
 	}, [messages]);
 
-	useEffect(() => {
-		if (!workerUrl || !resumeHash || !snippets.length) {
-			setEmbeddingStatus("idle");
-			return;
-		}
-
-		let isCancelled = false;
-
-		void (async () => {
-			setEmbeddingStatus("loading");
-
-			try {
-				const cachedValue =
-					typeof window !== "undefined"
-						? window.localStorage.getItem(
-								getEmbeddingsCacheKey(resumeHash, DEFAULT_EMBEDDING_MODEL),
-							)
-						: null;
-
-				if (cachedValue) {
-					const parsed = JSON.parse(cachedValue) as
-						| number[][]
-						| EmbeddingsCachePayload;
-					const parsedEmbeddings = Array.isArray(parsed)
-						? parsed
-						: parsed.embeddings;
-					const cacheAge = Array.isArray(parsed)
-						? Number.POSITIVE_INFINITY
-						: Date.now() - parsed.createdAt;
-					const cacheIsFresh = cacheAge <= EMBEDDINGS_CACHE_TTL_MS;
-
-					if (
-						cacheIsFresh &&
-						Array.isArray(parsedEmbeddings) &&
-						parsedEmbeddings.length === snippets.length
-					) {
-						if (!isCancelled) {
-							setSnippetEmbeddings(parsedEmbeddings);
-							setEmbeddingStatus("ready");
-						}
-
-						return;
-					}
-				}
-
-				const embeddings = await fetchEmbeddings(
-					workerUrl,
-					DEFAULT_EMBEDDING_MODEL,
-					snippets.map((snippet) => `${snippet.title}\n${snippet.text}`),
-				);
-
-				if (isCancelled) {
-					return;
-				}
-
-				setSnippetEmbeddings(embeddings);
-				setEmbeddingStatus("ready");
-				setStatusMessage("Embeddings cached and ready.");
-
-				if (typeof window !== "undefined") {
-					window.localStorage.setItem(
-						getEmbeddingsCacheKey(resumeHash, DEFAULT_EMBEDDING_MODEL),
-						JSON.stringify({
-							createdAt: Date.now(),
-							embeddings,
-						} satisfies EmbeddingsCachePayload),
-					);
-				}
-			} catch (error) {
-				const legacyEmbeddings = isEmbeddingsRateLimitError(error)
-					? readLegacyEmbeddingsCache({
-							hash: resumeHash,
-							model: DEFAULT_EMBEDDING_MODEL,
-							snippetCount: snippets.length,
-						})
-					: null;
-
-				if (legacyEmbeddings) {
-					if (!isCancelled) {
-						setSnippetEmbeddings(legacyEmbeddings);
-						setEmbeddingStatus("ready");
-						setStatusMessage(
-							"Using a previous embeddings cache because the embeddings API is rate-limited.",
-						);
-					}
-					return;
-				}
-
-				if (!isCancelled) {
-					setEmbeddingStatus("fallback");
-					setSnippetEmbeddings([]);
-					setStatusMessage(
-						"Embeddings are unavailable, so retrieval is using keyword matching instead.",
-					);
-				}
-			}
-		})();
-
-		return () => {
-			isCancelled = true;
-		};
-	}, [resumeHash, snippets, workerUrl]);
-
 	const addAssistantMessage = (
 		content: string,
 		options?: Partial<Pick<ChatMessage, "status" | "citations">>,
@@ -798,9 +627,13 @@ export function ResumeAssistant() {
 
 		try {
 			const recentMessages = getRecentConversationMessages(messages);
+			const { semanticSnippets } = await getHybridRelevantSnippets(
+				debugQuestion,
+				recentMessages,
+			);
 			const initialSnippets = buildInitialAssistantContextSnippets(
 				debugQuestion,
-				snippets,
+				mergeUniqueSnippets([...snippets, ...semanticSnippets]),
 			);
 			const response = await fetchAssistantRawProviderResponse({
 				workerUrl,
@@ -833,23 +666,73 @@ export function ResumeAssistant() {
 		}
 	};
 
-	const getKeywordRelevantSnippets = (
+	const getHybridRelevantSnippets = async (
 		question: string,
 		recentMessages: Array<{
 			role: "user" | "assistant";
 			content: string;
 		}>,
-	): RetrievalResult => {
+	) => {
 		const retrievalQuery = buildRetrievalQuery({
 			question,
 			recentMessages,
 		});
-
-		return {
+		const keywordResult = {
 			query: retrievalQuery,
-			mode: "keywords",
+			mode: "keywords" as const,
 			entries: rankSnippetEntriesByKeywords(retrievalQuery, snippets),
 		};
+
+		if (!workerUrl) {
+			return {
+				retrievalResult: keywordResult satisfies RetrievalResult,
+				keywordEntries: keywordResult.entries,
+				semanticEntries: [] as RetrievalResult["entries"],
+				semanticMatched: 0,
+				semanticSnippets: [] as ResumeSnippet[],
+			};
+		}
+
+		try {
+			const semanticResult = await fetchSemanticRelevantSnippets({
+				workerUrl,
+				question,
+				query: retrievalQuery,
+			});
+
+			if (!semanticResult.entries.length) {
+				return {
+					retrievalResult: keywordResult satisfies RetrievalResult,
+					keywordEntries: keywordResult.entries,
+					semanticEntries: [] as RetrievalResult["entries"],
+					semanticMatched: semanticResult.matched,
+					semanticSnippets: [] as ResumeSnippet[],
+				};
+			}
+
+			return {
+				retrievalResult: mergeRetrievalResults({
+					query: retrievalQuery,
+					keywordEntries: keywordResult.entries,
+					semanticEntries: semanticResult.entries,
+				}),
+				keywordEntries: keywordResult.entries,
+				semanticEntries: semanticResult.entries,
+				semanticMatched: semanticResult.matched,
+				semanticSnippets: semanticResult.snippets,
+			};
+		} catch {
+			setStatusMessage(
+				"Semantic retrieval is unavailable right now, so retrieval is using keyword matching.",
+			);
+			return {
+				retrievalResult: keywordResult satisfies RetrievalResult,
+				keywordEntries: keywordResult.entries,
+				semanticEntries: [] as RetrievalResult["entries"],
+				semanticMatched: 0,
+				semanticSnippets: [] as ResumeSnippet[],
+			};
+		}
 	};
 
 	const canSubmitDraft = Boolean(draft.trim()) && !isSending && Boolean(resume);
@@ -939,6 +822,12 @@ export function ResumeAssistant() {
 		setStatusMessage("");
 		updateDebugState({
 			retrievalResult: null,
+			keywordEntries: null,
+			semanticEntries: null,
+			semanticMatched: null,
+			initialSnippetIds: null,
+			finalSnippetIds: null,
+			recentContextIncluded: null,
 			usedClosestMatchFallback: false,
 			fallbackReason: null,
 			lastProvider: null,
@@ -950,12 +839,31 @@ export function ResumeAssistant() {
 		)
 			? getRecentConversationMessages([...messages, userMessage])
 			: [];
+		const recentContextIncluded = recentMessages.length > 0;
 
 		try {
+			const {
+				retrievalResult: hybridRetrievalResult,
+				keywordEntries,
+				semanticEntries,
+				semanticMatched,
+				semanticSnippets,
+			} = await getHybridRelevantSnippets(trimmedQuestion, recentMessages);
+			const snippetPool = mergeUniqueSnippets([
+				...snippets,
+				...semanticSnippets,
+			]);
 			const initialSnippets = buildInitialAssistantContextSnippets(
 				trimmedQuestion,
-				snippets,
+				snippetPool,
 			);
+			updateDebugState({
+				keywordEntries,
+				semanticEntries,
+				semanticMatched,
+				initialSnippetIds: initialSnippets.map((snippet) => snippet.id),
+				recentContextIncluded,
+			});
 
 			if (initialSnippets.length) {
 				const initialAssistantResponse = await fetchAssistantResponse({
@@ -978,20 +886,22 @@ export function ResumeAssistant() {
 				}
 			}
 
-			let retrievalResult: RetrievalResult | null = null;
-			retrievalResult = getKeywordRelevantSnippets(
-				trimmedQuestion,
-				recentMessages,
-			);
+			const retrievalResult: RetrievalResult = hybridRetrievalResult;
 			updateDebugState({
 				retrievalResult,
+				keywordEntries,
+				semanticEntries,
+				semanticMatched,
 				lastProvider: null,
 				providerContext: null,
 			});
 			const relevantSnippets = buildAssistantContextSnippets({
 				question: trimmedQuestion,
 				result: retrievalResult,
-				allSnippets: snippets,
+				allSnippets: snippetPool,
+			});
+			updateDebugState({
+				finalSnippetIds: relevantSnippets.map((snippet) => snippet.id),
 			});
 
 			if (relevantSnippets.length) {
@@ -1029,38 +939,36 @@ export function ResumeAssistant() {
 				updateDebugState({
 					usedClosestMatchFallback: false,
 					fallbackReason: retrievalResult
-						? "llm_and_embeddings_fell_back_to_local_match"
+						? "llm_and_retrieval_fell_back_to_local_match"
 						: "llm_fell_back_to_local_match",
 				});
 				return;
 			}
 
-			if (retrievalResult) {
-				const closestMatchFallback = shouldUseClosestMatchFallback({
-					query: retrievalResult.query,
-					result: retrievalResult,
-				})
-					? buildClosestMatchFallbackAnswer({
-							result: retrievalResult,
-						})
-					: null;
+			const closestMatchFallback = shouldUseClosestMatchFallback({
+				query: retrievalResult.query,
+				result: retrievalResult,
+			})
+				? buildClosestMatchFallbackAnswer({
+						result: retrievalResult,
+					})
+				: null;
 
-				if (closestMatchFallback) {
-					updateDebugState({
-						usedClosestMatchFallback: true,
-						fallbackReason: "embeddings_fell_back_to_closest_match",
-						lastProvider: null,
-						providerContext: null,
-					});
-					addAssistantMessage(closestMatchFallback.answer, {
-						status: closestMatchFallback.status,
-						citations: resolveResumeSnippetCitations(
-							closestMatchFallback.citations,
-							snippets,
-						),
-					});
-					return;
-				}
+			if (closestMatchFallback) {
+				updateDebugState({
+					usedClosestMatchFallback: true,
+					fallbackReason: "retrieval_fell_back_to_closest_match",
+					lastProvider: null,
+					providerContext: null,
+				});
+				addAssistantMessage(closestMatchFallback.answer, {
+					status: closestMatchFallback.status,
+					citations: resolveResumeSnippetCitations(
+						closestMatchFallback.citations,
+						snippetPool,
+					),
+				});
+				return;
 			}
 
 			addAssistantMessage(MISSING_INFORMATION_MESSAGE, {
@@ -1068,7 +976,7 @@ export function ResumeAssistant() {
 			});
 			updateDebugState({
 				usedClosestMatchFallback: false,
-				fallbackReason: "no_answer_after_llm_embeddings_and_local_match",
+				fallbackReason: "no_answer_after_llm_retrieval_and_local_match",
 				lastProvider: null,
 				providerContext: null,
 			});
@@ -1266,6 +1174,22 @@ export function ResumeAssistant() {
 											</span>
 										</p>
 										<p>
+											Recent context included:{" "}
+											<span className="font-mono">
+												{debugState.recentContextIncluded === null
+													? "n/a"
+													: debugState.recentContextIncluded
+														? "yes"
+														: "no"}
+											</span>
+										</p>
+										<p>
+											Semantic matched:{" "}
+											<span className="font-mono">
+												{debugState.semanticMatched ?? "n/a"}
+											</span>
+										</p>
+										<p>
 											Closest-match fallback:{" "}
 											<span className="font-mono">
 												{debugState.usedClosestMatchFallback ? "yes" : "no"}
@@ -1308,6 +1232,62 @@ export function ResumeAssistant() {
 													<p className="font-mono" key={entry.snippet.id}>
 														{entry.snippet.category} | {entry.score.toFixed(3)}{" "}
 														| {entry.snippet.title}
+													</p>
+												))}
+											</div>
+										) : null}
+										{debugState.keywordEntries?.length ? (
+											<div className="space-y-1">
+												<p className="font-medium text-foreground">
+													Keyword Matches
+												</p>
+												{debugState.keywordEntries.map((entry) => (
+													<p
+														className="font-mono"
+														key={`kw-${entry.snippet.id}`}
+													>
+														{entry.snippet.category} | {entry.score.toFixed(3)}{" "}
+														| {entry.snippet.title}
+													</p>
+												))}
+											</div>
+										) : null}
+										{debugState.semanticEntries?.length ? (
+											<div className="space-y-1">
+												<p className="font-medium text-foreground">
+													Semantic Matches
+												</p>
+												{debugState.semanticEntries.map((entry) => (
+													<p
+														className="font-mono"
+														key={`sem-${entry.snippet.id}`}
+													>
+														{entry.snippet.category} | {entry.score.toFixed(3)}{" "}
+														| {entry.snippet.title}
+													</p>
+												))}
+											</div>
+										) : null}
+										{debugState.initialSnippetIds?.length ? (
+											<div className="space-y-1">
+												<p className="font-medium text-foreground">
+													Initial Snippet IDs
+												</p>
+												{debugState.initialSnippetIds.map((id) => (
+													<p className="font-mono" key={`initial-${id}`}>
+														{id}
+													</p>
+												))}
+											</div>
+										) : null}
+										{debugState.finalSnippetIds?.length ? (
+											<div className="space-y-1">
+												<p className="font-medium text-foreground">
+													Final Snippet IDs
+												</p>
+												{debugState.finalSnippetIds.map((id) => (
+													<p className="font-mono" key={`final-${id}`}>
+														{id}
 													</p>
 												))}
 											</div>

--- a/src/lib/resume-assistant.ts
+++ b/src/lib/resume-assistant.ts
@@ -239,8 +239,27 @@ export type RetrievalEntry = {
 
 export type RetrievalResult = {
 	query: string;
-	mode: "embeddings" | "keywords";
+	mode: "embeddings" | "keywords" | "semantic" | "hybrid";
 	entries: RetrievalEntry[];
+};
+
+type SemanticRetrieveChunk = {
+	id: string;
+	sourceType: string;
+	title: string;
+	text: string;
+	url?: string;
+	slug?: string;
+	section: string;
+	score: number;
+};
+
+type SemanticRetrievePayload = {
+	ok: boolean;
+	status: "ready" | "no_match" | "insufficient_context" | "error";
+	matched: number;
+	chunks: SemanticRetrieveChunk[];
+	error?: string;
 };
 
 const assistantResponseSchema = z.object({
@@ -357,6 +376,46 @@ function tokenize(value: string) {
 	return normalizeText(value)
 		.split(/\s+/)
 		.filter((token) => token.length > 1);
+}
+
+function normalizeSemanticSourceType(
+	sourceType: string,
+): ResumeSnippet["category"] {
+	switch (sourceType) {
+		case "summary":
+		case "about":
+		case "skills":
+		case "links":
+		case "contact":
+		case "hero":
+		case "focus":
+		case "stats":
+		case "experience":
+		case "education":
+		case "project":
+		case "article":
+		case "case-study":
+		case "recommendation":
+			return sourceType;
+		default:
+			return "about";
+	}
+}
+
+function toSemanticResumeSnippet(chunk: SemanticRetrieveChunk): ResumeSnippet {
+	return {
+		id: `rag:${chunk.id}`,
+		title: chunk.title,
+		category: normalizeSemanticSourceType(chunk.sourceType),
+		text: chunk.text,
+		keywords: unique([
+			...tokenize(chunk.title),
+			...tokenize(chunk.text),
+			...tokenize(chunk.section),
+			...tokenize(chunk.slug || ""),
+		]),
+		url: chunk.url,
+	};
 }
 
 function unique<T>(items: T[]) {
@@ -490,6 +549,22 @@ function isDirectContentListingQuestion(question: string) {
 		/\bwhich\b.*\b(project|projects|blog|blogs|article|articles|post|posts|case study|case studies)\b/i,
 		/\bportfolio\b.*\b(work|projects|articles|writing)\b/i,
 		/\b(work|things)\b.*\b(built|made|wrote|published)\b/i,
+	].some((pattern) => pattern.test(question));
+}
+
+function isEnumerativeQuestion(question: string) {
+	return [
+		/\blist\b/i,
+		/\bshow\b/i,
+		/\bchronological\b/i,
+		/\btimeline\b/i,
+		/\bin order\b/i,
+		/\bexperience\b.*\border\b/i,
+		/\bproject(s)?\b/i,
+		/\barticle(s)?\b/i,
+		/\bblog(s)?\b/i,
+		/\bpost(s)?\b/i,
+		/\bcase stud(y|ies)\b/i,
 	].some((pattern) => pattern.test(question));
 }
 
@@ -2371,7 +2446,7 @@ export function shouldUseClosestMatchFallback(args: {
 	const hasStrongScoreGap = topEntry.score - secondScore >= 2;
 	const hasStrongKeywordSignal = topOverlapCount >= 2;
 	const hasStrongEmbeddingSignal =
-		result.mode === "embeddings" && topEntry.score >= 0.55;
+		result.mode !== "keywords" && topEntry.score >= 0.55;
 
 	return (
 		hasStrongKeywordSignal || hasStrongScoreGap || hasStrongEmbeddingSignal
@@ -2476,6 +2551,7 @@ export function buildAssistantChatRequestBody(args: {
 		structuredOutput = true,
 	} = args;
 	const broadProfileQuestion = isBroadProfileQuestion(question);
+	const enumerativeQuestion = isEnumerativeQuestion(question);
 	const snippetList = snippets
 		.map((snippet) => `[${snippet.id}] ${snippet.title}\n${snippet.text}`)
 		.join("\n\n");
@@ -2489,7 +2565,8 @@ export function buildAssistantChatRequestBody(args: {
 		action: "chat",
 		...(model ? { model } : {}),
 		temperature,
-		max_tokens: maxTokens ?? (broadProfileQuestion ? 700 : 500),
+		max_tokens:
+			maxTokens ?? (broadProfileQuestion || enumerativeQuestion ? 700 : 500),
 		response_format: structuredOutput
 			? {
 					type: "json_schema" as const,
@@ -2591,6 +2668,110 @@ export async function fetchEmbeddings(
 	}
 
 	return embeddings;
+}
+
+export function mergeUniqueSnippets(snippets: ResumeSnippet[]) {
+	const merged: ResumeSnippet[] = [];
+	const seenIds = new Set<string>();
+
+	for (const snippet of snippets) {
+		if (seenIds.has(snippet.id)) {
+			continue;
+		}
+
+		seenIds.add(snippet.id);
+		merged.push(snippet);
+	}
+
+	return merged;
+}
+
+export function mergeRetrievalResults(args: {
+	query: string;
+	keywordEntries: RetrievalEntry[];
+	semanticEntries: RetrievalEntry[];
+	limit?: number;
+}) {
+	const {
+		query,
+		keywordEntries,
+		semanticEntries,
+		limit = MAX_BROAD_CONTEXT_CHUNKS,
+	} = args;
+	const mergedEntries = new Map<string, RetrievalEntry>();
+
+	for (const entry of [...keywordEntries, ...semanticEntries]) {
+		const existing = mergedEntries.get(entry.snippet.id);
+
+		if (!existing || entry.score > existing.score) {
+			mergedEntries.set(entry.snippet.id, entry);
+		}
+	}
+
+	return {
+		query,
+		mode:
+			keywordEntries.length && semanticEntries.length
+				? ("hybrid" as const)
+				: semanticEntries.length
+					? ("semantic" as const)
+					: ("keywords" as const),
+		entries: Array.from(mergedEntries.values())
+			.sort((a, b) => compareSnippetsForQuestion(query, a, b))
+			.slice(0, limit),
+	} satisfies RetrievalResult;
+}
+
+export async function fetchSemanticRelevantSnippets(args: {
+	workerUrl: string;
+	question: string;
+	query: string;
+}) {
+	const response = await fetch(
+		new URL("/assistant-retrieve", args.workerUrl).toString(),
+		{
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				question: args.question,
+				query: args.query,
+			}),
+		},
+	);
+
+	if (!response.ok) {
+		throw new Error(
+			`Semantic retrieval request failed with status ${response.status}.`,
+		);
+	}
+
+	const payload = (await parseAssistantJsonPayload(
+		response,
+	)) as SemanticRetrievePayload;
+
+	if (
+		!payload?.ok ||
+		payload.status !== "ready" ||
+		!Array.isArray(payload.chunks)
+	) {
+		return {
+			matched: payload?.matched || 0,
+			entries: [] as RetrievalEntry[],
+			snippets: [] as ResumeSnippet[],
+		};
+	}
+
+	const snippets = payload.chunks.map(toSemanticResumeSnippet);
+	return {
+		matched: payload.matched,
+		snippets,
+		entries: payload.chunks.map((chunk, index) => ({
+			snippet: snippets[index],
+			score: Number(chunk.score || 0),
+		})),
+	};
 }
 
 export async function fetchAssistantResponse(args: {


### PR DESCRIPTION
Introduce a Cloudflare semantic retrieval flow and UI/debugging support.

- Add new /assistant-retrieve endpoint and handler (handleRetrieveRequest) with request validation, CORS handling, and structured RagRetrieveResponse types.
- Extend rag types with RagRetrieveChunk and RagRetrieveResponse and update jsonResponse typing.
- Wire up new route in index.ts and add RAG_EMBED_MODEL env var support; update assistant embeddings proxy to use Workers AI.run when available and return normalized embedding objects.
- Update rag-app UI: add retrieval query field, buttons for /assistant-retrieve and frontend-style /assistant-routed, client helpers (fetchSemanticRetrieval, createFrontendStyleRoutedRequest) and frontend routing logic to inspect retrieval payloads.
- Add server-side retrieval -> ready/no_match/insufficient_context responses mapping to chunk metadata returned to client.
- Resume assistant refactor: remove legacy embedding cache/embedding-only flow and integrate semantic retrieval (fetchSemanticRelevantSnippets), hybrid merging of keyword+semantic results (mergeRetrievalResults, mergeUniqueSnippets), normalize semantic chunks into ResumeSnippet, and enhance debug state and UI to show semantic/keyword matches, snippet IDs, and retrieval metrics.
- Update tests to mock env.AI.run for embeddings and adjust JSON parsing typings in tests.
- Add additional allowed origins in wrangler.jsonc.

These changes add a retrieval-first debugging path, unify semantic results into the existing assistant flows, and make the worker use Workers AI for embeddings if configured.