### PR TITLE
ci: use Node 22 for Cloudflare worker workflow

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "22"
 
 jobs:
   test-and-deploy:


### PR DESCRIPTION
This updates the Cloudflare worker deploy workflow to Node 22 so it remains compatible with `wrangler@4.87.0`, which now hard-fails on Node versions below 22.

Why this is needed:
- Dependabot PR #73 bumps `wrangler` from `4.83.0` to `4.87.0`
- Wrangler `4.87.0` requires Node 22+
- `.github/workflows/deploy-worker.yml` was still pinned to Node 20

Validation:
- `yarn lint`
- `yarn typecheck`
- `yarn test` in `cloudflare-worker`

After this merges, PR #73 should be safe to re-check and merge.