### PR TITLE
[codex] Fix assistant citations and fallback routing

### DIFF
--- a/cloudflare-worker/src/__tests__/worker.test.js
+++ b/cloudflare-worker/src/__tests__/worker.test.js
@@ -2189,6 +2189,108 @@ describe("/assistant-routed", () => {
 		});
 	});
 
+	it("continues past portfolio-rag when portfolio-rag returns missing", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					choices: [
+						{
+							message: {
+								content:
+									'{"status":"answered","answer":"Hugging Face handled it after RAG missed.","citations":["summary"]}',
+							},
+						},
+					],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			),
+		);
+
+		const aiRun = vi
+			.fn()
+			.mockResolvedValueOnce({
+				data: [[0.1, 0.2, 0.3]],
+			})
+			.mockResolvedValueOnce({
+				response:
+					'{"status":"missing","answer":"I don\'t have that information available.","citations":[]}',
+			});
+
+		const response = await worker.fetch(
+			buildPathRequest("/assistant-routed", "POST", ALLOWED_ORIGIN, {
+				action: "chat",
+				model: "openai/gpt-4.1-mini",
+				messages: [
+					{
+						role: "user",
+						content: "Tell me about Hassan's technical background.",
+					},
+				],
+			}),
+			{
+				...env,
+				HUGGING_FACE_API_TOKEN: "hf_test",
+				HUGGING_FACE_MODEL: "Qwen/Qwen2.5-7B-Instruct-1M",
+				AI: {
+					run: aiRun,
+				},
+				VECTOR_INDEX: {
+					query: vi.fn().mockResolvedValue({
+						matches: [
+							{
+								id: "vec-1",
+								score: 0.91,
+								metadata: {
+									objectKey: "chunks/vec-1.json",
+								},
+							},
+						],
+					}),
+				},
+				RAG_CHUNKS_BUCKET: createMockR2Bucket({
+					"chunks/vec-1.json": JSON.stringify({
+						vectorId: "vec-1",
+						id: "summary",
+						text: "Hassan builds reliable systems and infrastructure.",
+						sourceType: "about",
+						title: "Professional Summary",
+						slug: "summary",
+						url: "https://example.com/about",
+						section: "summary",
+					}),
+				}),
+				RAG_CHAT_MODEL: "@cf/meta/llama-3.1-8b-instruct",
+				RAG_EMBED_MODEL: "@cf/baai/bge-small-en-v1.5",
+				ASSISTANT_PROVIDER_PRIORITY: "portfolio-rag,huggingface",
+			},
+		);
+		const payload = await response.json();
+		const providerAttempts = JSON.parse(
+			response.headers.get("X-Assistant-Providers") || "[]",
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("X-Assistant-Provider")).toBe("huggingface");
+		expect(JSON.parse(payload.choices[0].message.content)).toEqual({
+			status: "answered",
+			answer: "Hugging Face handled it after RAG missed.",
+			citations: ["summary"],
+		});
+		expect(providerAttempts).toEqual([
+			{
+				provider: "portfolio-rag",
+				status: 200,
+				error: "Assistant returned missing",
+			},
+			{
+				provider: "huggingface",
+				status: 200,
+				error: null,
+			},
+		]);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
 	it("falls back to groq_backup when the primary groq provider misses", async () => {
 		const fetchSpy = vi.spyOn(globalThis, "fetch");
 
@@ -2254,22 +2356,35 @@ describe("/assistant-routed", () => {
 		expect(fetchSpy).toHaveBeenCalledTimes(2);
 	});
 
-	it("skips groq_backup and continues to Cloudflare when Groq hits capacity limits", async () => {
+	it("tries groq_backup when Groq hits capacity limits", async () => {
 		const fetchSpy = vi.spyOn(globalThis, "fetch");
-		const aiRun = vi.fn().mockResolvedValue({
-			response:
-				'{"status":"answered","answer":"Cloudflare answer","citations":["summary"]}',
-		});
 
-		fetchSpy.mockResolvedValueOnce(
-			new Response(
-				JSON.stringify({
-					error:
-						"Rate limit reached for model `openai/gpt-oss-120b` on tokens per day",
-				}),
-				{ status: 429, headers: { "Content-Type": "application/json" } },
-			),
-		);
+		fetchSpy
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						error:
+							"Rate limit reached for model `openai/gpt-oss-120b` on tokens per day",
+					}),
+					{ status: 429, headers: { "Content-Type": "application/json" } },
+				),
+			)
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						choices: [
+							{
+								message: {
+									content:
+										'{"status":"answered","answer":"Groq backup answered after the primary rate limit.","citations":["summary"]}',
+								},
+								finish_reason: "stop",
+							},
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			);
 
 		const response = await worker.fetch(
 			buildPathRequest("/assistant-routed", "POST", ALLOWED_ORIGIN, {
@@ -2284,22 +2399,17 @@ describe("/assistant-routed", () => {
 				GROQ_API_KEY: "groq_test",
 				GROQ_MODEL: "openai/gpt-oss-120b",
 				GROQ_BACKUP_MODEL: "llama-3.1-8b-instant",
-				CLOUDFLARE_AI_MODEL: "@cf/meta/llama-3.1-8b-instruct",
-				AI: {
-					run: aiRun,
-				},
 				ASSISTANT_PROVIDER_PRIORITY: "groq,groq_backup,cloudflare",
 			},
 		);
 		const payload = await response.json();
 
 		expect(response.status).toBe(200);
-		expect(response.headers.get("X-Assistant-Provider")).toBe("cloudflare");
-		expect(fetchSpy).toHaveBeenCalledTimes(1);
-		expect(aiRun).toHaveBeenCalledTimes(1);
+		expect(response.headers.get("X-Assistant-Provider")).toBe("groq_backup");
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
 		expect(JSON.parse(payload.choices[0].message.content)).toEqual({
 			status: "answered",
-			answer: "Cloudflare answer",
+			answer: "Groq backup answered after the primary rate limit.",
 			citations: ["summary"],
 		});
 	});

--- a/cloudflare-worker/src/utils/providers.ts
+++ b/cloudflare-worker/src/utils/providers.ts
@@ -465,6 +465,21 @@ function isGroqCapacityLikeFailure(status: number, payload: unknown) {
 	);
 }
 
+function _isGroqSharedQuotaFailure(status: number, payload: unknown) {
+	const normalizedError = normalizeAssistantErrorPayload(payload, "")
+		.toLowerCase()
+		.trim();
+
+	return (
+		status >= 400 ||
+		normalizedError.includes("rate limit reached") ||
+		normalizedError.includes("request too large") ||
+		normalizedError.includes("tokens per minute") ||
+		normalizedError.includes("tokens per day") ||
+		normalizedError.includes("service tier")
+	);
+}
+
 function isGroqFallbackWorthyFailure(status: number, payload: unknown) {
 	if (status > 400 || isGroqCapacityLikeFailure(status, payload)) {
 		return true;

--- a/cloudflare-worker/src/utils/providers.ts
+++ b/cloudflare-worker/src/utils/providers.ts
@@ -465,21 +465,6 @@ function isGroqCapacityLikeFailure(status: number, payload: unknown) {
 	);
 }
 
-function isGroqSharedQuotaFailure(status: number, payload: unknown) {
-	const normalizedError = normalizeAssistantErrorPayload(payload, "")
-		.toLowerCase()
-		.trim();
-
-	return (
-		status >= 400 ||
-		normalizedError.includes("rate limit reached") ||
-		normalizedError.includes("request too large") ||
-		normalizedError.includes("tokens per minute") ||
-		normalizedError.includes("tokens per day") ||
-		normalizedError.includes("service tier")
-	);
-}
-
 function isGroqFallbackWorthyFailure(status: number, payload: unknown) {
 	if (status > 400 || isGroqCapacityLikeFailure(status, payload)) {
 		return true;
@@ -1270,7 +1255,6 @@ export async function callAssistantChatWithRouting(
 	body: AssistantChatBody,
 ) {
 	const providerAttempts: ProviderAttempt[] = [];
-	let skipGroqBackup = false;
 	let lastMissingResponse: {
 		payload: unknown;
 		status: number;
@@ -1427,13 +1411,6 @@ export async function callAssistantChatWithRouting(
 
 			if (
 				!groqResponse.ok &&
-				isGroqSharedQuotaFailure(groqResponse.status, groqResponse.payload)
-			) {
-				skipGroqBackup = true;
-			}
-
-			if (
-				!groqResponse.ok &&
 				!isGroqFallbackWorthyFailure(groqResponse.status, groqResponse.payload)
 			) {
 				return jsonResponse(
@@ -1447,10 +1424,6 @@ export async function callAssistantChatWithRouting(
 		}
 
 		if (provider === "groq_backup") {
-			if (skipGroqBackup) {
-				continue;
-			}
-
 			const groqBackupResponse = await callGroqBackup(body, env);
 			const normalizedPayload = groqBackupResponse.ok
 				? normalizeAssistantChatPayload(
@@ -1720,21 +1693,36 @@ export async function callAssistantChatWithRouting(
 					},
 				);
 
-				return jsonResponse(
-					toChatCompletionsPayload(
-						JSON.stringify(ragPayload),
-						env.RAG_CHAT_MODEL || "portfolio-rag",
-					),
-					200,
-					buildProviderContextHeaders("portfolio-rag", [
-						...providerAttempts,
-						{
-							provider: "portfolio-rag",
-							status: 200,
-							error: null,
-						},
-					]),
+				const normalizedPayload = toChatCompletionsPayload(
+					JSON.stringify(ragPayload),
+					env.RAG_CHAT_MODEL || "portfolio-rag",
 				);
+
+				if (!isMissingAssistantResponse(normalizedPayload)) {
+					return jsonResponse(
+						normalizedPayload,
+						200,
+						buildProviderContextHeaders("portfolio-rag", [
+							...providerAttempts,
+							{
+								provider: "portfolio-rag",
+								status: 200,
+								error: null,
+							},
+						]),
+					);
+				}
+
+				lastMissingResponse = {
+					payload: normalizedPayload,
+					status: 200,
+					provider: "portfolio-rag",
+				};
+				providerAttempts.push({
+					provider: "portfolio-rag",
+					status: 200,
+					error: "Assistant returned missing",
+				});
 			} catch (error) {
 				providerAttempts.push({
 					provider: "portfolio-rag",

--- a/cloudflare-worker/wrangler.jsonc
+++ b/cloudflare-worker/wrangler.jsonc
@@ -32,7 +32,7 @@
     "CONTACT_EMAIL": "hassanraza632@gmail.com",
     "FROM_EMAIL": "noreply@contact.hassanraza.us",
     "GITHUB_MODELS_CHAT_MODEL": "openai/gpt-4o-mini",
-    "ASSISTANT_PROVIDER_PRIORITY": "groq,groq_backup,cloudflare,portfolio-rag,github-models,huggingface",
+    "ASSISTANT_PROVIDER_PRIORITY": "groq,groq_backup,cloudflare,huggingface,github-models,portfolio-rag",
     "GROQ_MODEL": "openai/gpt-oss-120b",
     // "GROQ_BACKUP_MODEL": "llama-3.1-8b-instant",
     "GROQ_BACKUP_MODEL": "llama-3.3-70b-versatile",

--- a/src/lib/resume-assistant.ts
+++ b/src/lib/resume-assistant.ts
@@ -296,12 +296,51 @@ function replaceInlineCitationIdsWithTitles(
 	const snippetTitleById = new Map(
 		snippets.map((snippet) => [snippet.id, snippet.title.trim()]),
 	);
+	const normalizeComparableText = (value: string) =>
+		value
+			.toLowerCase()
+			.replace(/\*\*/g, "")
+			.replace(/\*/g, "")
+			.replace(/[\u2010-\u2015]/g, "-")
+			.replace(/\s+/g, " ")
+			.trim();
 
 	return answer.replace(
 		/\[(rag:[^\]]+|summary|about|skills|links|contact|hero|focus|stats|experience:[^\]]+|education:[^\]]+|project:[^\]]+|article:[^\]]+|case-study:[^\]]+|recommendation:[^\]]+)\]/gi,
-		(match) => {
+		(match, _citationId, offset) => {
+			const start = typeof offset === "number" ? offset : 0;
 			const citationId = match.slice(1, -1);
-			return snippetTitleById.get(citationId) || match;
+			const title = snippetTitleById.get(citationId);
+
+			if (!title) {
+				return match;
+			}
+
+			const recentContext = answer.slice(Math.max(0, start - 240), start);
+			const normalizedRecentContext = normalizeComparableText(recentContext);
+			const normalizedTitle = normalizeComparableText(title);
+			const nextSlice = answer.slice(start + match.length);
+			const nextNonWhitespace = nextSlice.match(/\S/)?.[0] || "";
+			const previousNonWhitespace =
+				recentContext.match(/\S(?=\s*$)/)?.[0] || "";
+
+			if (
+				normalizedTitle &&
+				normalizedRecentContext.includes(normalizedTitle)
+			) {
+				return "";
+			}
+
+			if (
+				/[.?!:;)\]|*]/.test(previousNonWhitespace) &&
+				(!nextNonWhitespace ||
+					nextNonWhitespace === "[" ||
+					/[.?!,;:)}\]|]/.test(nextNonWhitespace))
+			) {
+				return "";
+			}
+
+			return title;
 		},
 	);
 }

--- a/src/lib/resume-assistant.ts
+++ b/src/lib/resume-assistant.ts
@@ -319,23 +319,10 @@ function replaceInlineCitationIdsWithTitles(
 			const recentContext = answer.slice(Math.max(0, start - 240), start);
 			const normalizedRecentContext = normalizeComparableText(recentContext);
 			const normalizedTitle = normalizeComparableText(title);
-			const nextSlice = answer.slice(start + match.length);
-			const nextNonWhitespace = nextSlice.match(/\S/)?.[0] || "";
-			const previousNonWhitespace =
-				recentContext.match(/\S(?=\s*$)/)?.[0] || "";
 
 			if (
 				normalizedTitle &&
 				normalizedRecentContext.includes(normalizedTitle)
-			) {
-				return "";
-			}
-
-			if (
-				/[.?!:;)\]|*]/.test(previousNonWhitespace) &&
-				(!nextNonWhitespace ||
-					nextNonWhitespace === "[" ||
-					/[.?!,;:)}\]|]/.test(nextNonWhitespace))
 			) {
 				return "";
 			}


### PR DESCRIPTION
## What changed
- fixed assistant answer normalization so leaked inline citation ids are replaced with real snippet titles instead of disappearing during rendering
- made the inline citation-title recovery smarter so appended citation ids are stripped when the visible title is already present nearby
- updated routed provider behavior so `portfolio-rag` treats `missing` responses like other providers and continues fallback when another provider can still answer
- kept `groq_backup` enabled after primary Groq capacity/rate-limit failures and aligned the worker tests with that routing behavior
- updated worker tests to cover the `portfolio-rag -> missing -> next provider answered` path
- adjusted worker provider priority in `wrangler.jsonc`

## Why
There were two user-facing issues and one routing inconsistency:
- some assistant responses lost visible project/article names because providers leaked raw citation ids like `[project:...]` into the structured `answer`
- some responses mixed linked titles and plain text awkwardly when citation ids were appended after already-visible titles
- `portfolio-rag` could short-circuit routed fallback on a `missing` response while other providers did not, making fallback behavior inconsistent

## Impact
- assistant responses keep the human-readable titles instead of rendering blanks
- citation cleanup is more stable around inline links and repeated titles
- routed provider fallback is more predictable, and `groq_backup` remains available when the primary Groq provider is rate-limited

## Validation
- `yarn lint`
- `yarn typecheck`
- `cd cloudflare-worker && yarn test`
- `cd cloudflare-worker && yarn typecheck`