### PR TITLE
chore: add Cursor Cloud environment configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,3 +58,33 @@ Update the maintenance docs in the same change whenever you modify:
 - SEO behavior or structured data
 - worker endpoints, providers, retrieval, or deployment flow
 - CI, deployment, or required environment variables
+
+## Cursor Cloud specific instructions
+
+### Services
+
+| Service | Command | URL | Notes |
+|---|---|---|---|
+| Next.js dev server (required for site work) | `yarn dev` | `http://localhost:3000` | Regenerates `resume.json` and `search-index.json` before starting |
+| Static export preview (optional) | `yarn build && yarn start` | `http://localhost:3000` | Serves the `out/` directory |
+| Cloudflare Worker (optional) | `cd cloudflare-worker && yarn dev` | `http://127.0.0.1:8787` | Needed for contact form, AI assistant, and CMS OAuth E2E |
+
+No `.env` file is required for basic site development. Public defaults live in `config/public-env.defaults.json`. When the site runs on `localhost`, it auto-targets the local worker via `NEXT_PUBLIC_LOCAL_WORKER_URL` (`http://127.0.0.1:8787`).
+
+### Install and validation
+
+Install both workspaces after pulling changes:
+
+```bash
+yarn install --frozen-lockfile
+cd cloudflare-worker && yarn install --frozen-lockfile
+```
+
+Standard checks (see Validation section above): `yarn lint`, `yarn typecheck`, `yarn build`, `cd cloudflare-worker && yarn test`, `cd cloudflare-worker && yarn typecheck`.
+
+### Gotchas
+
+- `yarn dev` runs content generators (`resume:generate`, `search:generate`) before Next.js starts; expect a short delay on first launch.
+- `yarn build` may print an ESLint-not-installed warning during the Next.js build step; the build still succeeds because linting is handled by Biome via `yarn lint`.
+- Worker E2E features (contact email, AI assistant, Decap CMS OAuth) require `cloudflare-worker/.dev.vars` secrets or `yarn dev:remote` with Cloudflare credentials. These are not needed for static site pages, search, or content editing in the repo.
+- Node 20+ works for the root app; the worker CI uses Node 22. Both install cleanly on Node 22.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds repo-level Cloud Agent configuration so future agents reuse the same dev environment setup.

## Changes

### `.cursor/environment.json` (new)

Cursor reads this file **before** personal or team saved environments. It is the official config path (singular `environment.json`, not `environments.json`).

Configured fields:

- **`install`** — idempotent dependency refresh on VM startup (root + `cloudflare-worker` Yarn installs)
- **`ports`** — 3000 (Next.js) and 8787 (Wrangler)
- **`terminals`** — `yarn dev` and optional `cloudflare-worker` dev server
- **`agentCanUpdateSnapshot`** — allows pinning the snapshot ID after setup

### `AGENTS.md`

- Documents `.cursor/environment.json` and how to paste a snapshot ID from the [Cloud Agents dashboard](https://cursor.com/dashboard?tab=cloud-agents)
- Existing Cloud-specific service/install/validation notes

## Snapshot ID (one manual step after merge)

The snapshot ID from this setup session cannot be read from inside the VM. After merging:

1. Open [Cloud Agents → Environments](https://cursor.com/dashboard?tab=cloud-agents)
2. Save this environment (Personal or Team) if not already saved
3. Copy the snapshot ID from the environment details
4. Add it to `.cursor/environment.json`:

```json
{
  "snapshot": "snapshot-YYYYMMDD-...",
  ...
}
```

Until `snapshot` is set, agents still work via the `install` script on the default base image; adding the snapshot speeds up subsequent boots.

## Validation

Environment was verified in the prior setup run: `yarn lint`, `yarn typecheck`, `yarn build`, and `cloudflare-worker` tests all pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb98457d-182d-4fe6-b751-f5b5d60e466a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb98457d-182d-4fe6-b751-f5b5d60e466a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

