### PR TITLE
chore: add .cursor/environment.json for Cloud Agent snapshot config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,28 @@
+{
+  "name": "personal-portfolio",
+  "snapshot": "snapshot-20260607-fb4c6f7e-f523-4c29-bdb7-97820a2ff587",
+  "agentCanUpdateSnapshot": true,
+  "install": "yarn install --frozen-lockfile\ncd cloudflare-worker && yarn install --frozen-lockfile",
+  "ports": [
+    {
+      "name": "Next.js dev server",
+      "port": 3000
+    },
+    {
+      "name": "Cloudflare Worker",
+      "port": 8787
+    }
+  ],
+  "terminals": [
+    {
+      "name": "Next.js dev server",
+      "command": "yarn dev",
+      "description": "Regenerates resume/search artifacts, then serves the portfolio at http://localhost:3000"
+    },
+    {
+      "name": "Cloudflare Worker",
+      "command": "cd cloudflare-worker && yarn dev",
+      "description": "Optional Wrangler dev server at http://127.0.0.1:8787 for contact, assistant, and CMS OAuth E2E"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,10 @@ Update the maintenance docs in the same change whenever you modify:
 
 ## Cursor Cloud specific instructions
 
+Repo-level cloud agent configuration lives in `.cursor/environment.json`. Cursor resolves this file before personal or team saved environments.
+
+After saving a Cloud Agents environment snapshot from the dashboard, paste its ID into the `snapshot` field in `.cursor/environment.json` so future agents boot from the cached VM image. Snapshot IDs are available at [Cloud Agents → Environments](https://cursor.com/dashboard?tab=cloud-agents) after you save the environment.
+
 ### Services
 
 | Service | Command | URL | Notes |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds repo-level Cursor Cloud Agent configuration so future agents boot from an optimized, snapshot-backed VM image instead of provisioning from scratch each run.

### Changes

- **`.cursor/environment.json`** (new): Defines the cloud agent environment for this repo.
  - `snapshot`: `snapshot-20260607-fb4c6f7e-f523-4c29-bdb7-97820a2ff587` — boots agents from the cached VM image (the "optimized" path).
  - `install`: installs both workspaces (`yarn install --frozen-lockfile` in root and `cloudflare-worker`).
  - `ports` / `terminals`: wires up the Next.js dev server (`:3000`) and the optional Cloudflare Worker (`:8787`), matching the service table in `AGENTS.md`.
  - `agentCanUpdateSnapshot: true` so agents can refresh the snapshot when the environment changes.
- **`AGENTS.md`**: documents that `.cursor/environment.json` is resolved before personal/team saved environments, and how to refresh the `snapshot` field from the dashboard.

### Notes

- Format follows the prior reference commit `c813e1b`, with the addition of the `snapshot` field populated with the provided ID.
- `environment.json` validated as well-formed JSON.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://thinkgeniux.slack.com/archives/C0B8KN1U87M/p1780843552543559?thread_ts=1780843552.543559&cid=C0B8KN1U87M)

<div><a href="https://cursor.com/agents/bc-9da001f9-eb59-5b14-991f-083dda2c2d68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9da001f9-eb59-5b14-991f-083dda2c2d68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

